### PR TITLE
Further ZAP Scan improvments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,8 @@ script:
   - docker images
 
 deploy:
-  -  provider: script
-     skip_cleanup: true
-     script: bash deploy.sh
-     on:
-       branch: develop
-  -  provider: script
-     skip_cleanup: true
-     script: bash deploy.sh
-     on:
-       branch: master
+  - provider: script
+    skip_cleanup: true
+    script: bash deploy.sh
+    on:
+      all_branches: true

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,4 +3,11 @@
 echo "Docker Login"
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 echo "Pushing to Dockerhub"
-echo $(docker push securecodebox/zap)
+if [[ $TRAVIS_BRANCH =~ ^master|develop$ ]]
+then
+    echo "Pushing all tags"
+    echo $(docker push securecodebox/zap)
+else
+    echo "Pushing only branch Tag"
+    echo $(docker push securecodebox/zap:$TRAVIS_BRANCH)
+fi

--- a/dockerfiles/init.sh
+++ b/dockerfiles/init.sh
@@ -11,4 +11,4 @@ fi
 
 sleep 5
 
-java -Djava.security.egd=file:/dev/./urandom -Xmx1024m -jar /home/zap/app.jar
+java -Djava.security.egd=file:/dev/./urandom -Xmx2G -jar /home/zap/app.jar

--- a/dockerfiles/init.sh
+++ b/dockerfiles/init.sh
@@ -11,4 +11,4 @@ fi
 
 sleep 5
 
-java -Djava.security.egd=file:/dev/./urandom -Xmx512m -jar /home/zap/app.jar
+java -Djava.security.egd=file:/dev/./urandom -Xmx1024m -jar /home/zap/app.jar

--- a/dockerfiles/init.sh
+++ b/dockerfiles/init.sh
@@ -7,7 +7,7 @@ if [ `id -u` -ge 1000 ]; then
     rm /tmp/passwd
 fi
 
-/zap/zap.sh -daemon -dir /home/zap/ -port 8090 -host 0.0.0.0 -config api.disablekey=true -config api.addrs.addr.name=.* -config api.addrs.addr.regex=true -addoninstall soap -addoninstall openapi &
+/zap/zap.sh -Xmx3G -daemon -dir /home/zap/ -port 8090 -host 0.0.0.0 -config api.disablekey=true -config api.addrs.addr.name=.* -config api.addrs.addr.regex=true -addoninstall soap -addoninstall openapi &
 
 sleep 5
 

--- a/src/main/java/io/securecodebox/zap/jobs/definition/EngineWorkerJob.java
+++ b/src/main/java/io/securecodebox/zap/jobs/definition/EngineWorkerJob.java
@@ -183,6 +183,7 @@ public class EngineWorkerJob implements JobRunnable {
             }
 
             if (config.isFilterScannerResults()) {
+                log.info("Removing duplicate findings");
                 removeDuplicateScanResults(resultFindings);
             }
 
@@ -290,6 +291,8 @@ public class EngineWorkerJob implements JobRunnable {
             return;
         }
 
+        log.info("Finding count before duplicate removal: '{}'", findings.size());
+
         Set<String> uniqueUrls = new HashSet<>();
 
         Set<Finding> findingSet = new HashSet<>();
@@ -302,6 +305,8 @@ public class EngineWorkerJob implements JobRunnable {
         }
         findings.clear();
         findings.addAll(findingSet);
+
+        log.info("Finding count after duplicate removal: '{}'", findings.size());
     }
 
     public static void removeDuplicateSpiderResults(List<Finding> findings) {

--- a/src/main/java/io/securecodebox/zap/jobs/definition/EngineWorkerJob.java
+++ b/src/main/java/io/securecodebox/zap/jobs/definition/EngineWorkerJob.java
@@ -88,10 +88,10 @@ public class EngineWorkerJob implements JobRunnable {
                 performSpiderTask(publisher, spiderTask);
             } catch (ClientApiException | RuntimeException e) {
                 log.error("Job execution error!", e);
-                taskService.reportFailure(e, spiderTask);
+                taskService.reportFailure(spiderTask.getJobId(), "Spider Job execution error");
             } catch (UnsupportedEncodingException e) {
                 log.error("Couldn't define session management!", e);
-                taskService.reportFailure(e, spiderTask);
+                taskService.reportFailure(spiderTask.getJobId(), "Could not define session management");
             }
         } else {
             publisher.info("No spider tasks fetched.");
@@ -103,10 +103,10 @@ public class EngineWorkerJob implements JobRunnable {
                 performScannerTask(publisher, scannerTask);
             } catch (ClientApiException | RuntimeException e) {
                 log.error("Job execution error!", e);
-                taskService.reportFailure(e, scannerTask);
+                taskService.reportFailure(scannerTask.getJobId(), "Scanner Job Execution error");
             } catch (UnsupportedEncodingException e) {
                 log.error("Couldn't define session management!", e);
-                taskService.reportFailure(e, scannerTask);
+                taskService.reportFailure(scannerTask.getJobId(), "Could not define session management");
             }
         } else {
             publisher.info("No scanner tasks fetched.");

--- a/src/main/java/io/securecodebox/zap/service/engine/EngineTaskApiClient.java
+++ b/src/main/java/io/securecodebox/zap/service/engine/EngineTaskApiClient.java
@@ -142,7 +142,7 @@ public class EngineTaskApiClient {
     void completeTask(CompleteTask task) {
 
         String url = config.getProcessEngineApiUrl() + "/box/jobs/" + task.getJobId() + "/result";
-        log.info("Post completeTask({}) via {}", task, url);
+        log.debug("Post completeTask({}) via {}", task.getJobId(), url);
 
         ResponseEntity<String> completedTask = restTemplate.postForEntity(url, task, String.class);
         log.info(String.format("Completed the task: %s", task.getJobId()));

--- a/src/main/java/io/securecodebox/zap/service/engine/EngineTaskApiClient.java
+++ b/src/main/java/io/securecodebox/zap/service/engine/EngineTaskApiClient.java
@@ -78,25 +78,6 @@ public class EngineTaskApiClient {
         log.info("EngineApiClient is using {} as Engine Base URL.", config.getProcessEngineApiUrl());
     }
 
-    int getTaskCountByTopic(ZapTopic topicName) {
-        String url = config.getProcessEngineApiUrl() + "/count?topicName=" + topicName;
-        log.debug("Call getTaskCountByTopic() via {}", url);
-
-        ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
-        Map<String, Object> result = jsonStringToMap(response.getBody());
-
-        if (response.getStatusCode().is2xxSuccessful() && response.getHeaders().getContentType().isCompatibleWith(MediaType.APPLICATION_JSON)) {
-            if (result.size() == 1 && result.containsKey("count")) {
-                return Integer.parseInt(result.get("count").toString());
-            } else {
-                throw new ResourceAccessException("Status Code");
-            }
-        } else {
-            log.error("HTTP response error: {}", response.getStatusCode());
-            throw new ResourceAccessException("Status Code");
-        }
-    }
-
     /**
      * Returns true if the configured SCB Engine API is available and at least one processModell is deployed.
      * @return
@@ -171,18 +152,5 @@ public class EngineTaskApiClient {
             log.error(String.format("Error reporting failure: %s, the return code is: %s with result: %s", failure, statusCode, completedTask.getBody()));
         }
 
-    }
-
-
-    private static Map<String, Object> jsonStringToMap(String json) {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String, Object> map = new HashMap<>(16);
-
-        try {
-            map = mapper.readValue(json, new TypeReference<Map<String, String>>() {});
-        } catch (IOException e) {
-            log.error("Couldn't parse object to map", e);
-        }
-        return map;
     }
 }

--- a/src/main/java/io/securecodebox/zap/service/engine/ZapTaskService.java
+++ b/src/main/java/io/securecodebox/zap/service/engine/ZapTaskService.java
@@ -68,6 +68,7 @@ public class ZapTaskService extends TaskService {
 
     public List<Finding> createFindings(String zapResult) {
 
+        log.info("Deserializing results to findings.");
         ObjectMapper objectMapper = new ObjectMapper();
         try {
             return objectMapper.readValue(zapResult, objectMapper.getTypeFactory()

--- a/src/main/java/io/securecodebox/zap/service/engine/ZapTaskService.java
+++ b/src/main/java/io/securecodebox/zap/service/engine/ZapTaskService.java
@@ -60,13 +60,10 @@ public class ZapTaskService extends TaskService {
         return task;
     }
 
-    public void reportFailure(Exception exception, ZapTask zapTask){
+    public void reportFailure(String jobId, String message){
+        ScanFailure failure = new ScanFailure(config.getAppId(), jobId, message, "");
 
-        if(exception != null) {
-            ScanFailure failure = new ScanFailure(config.getAppId(), zapTask.getJobId(), exception.getMessage(), "Cause: " + exception.getCause());
-
-            taskApiClient.reportFailure(failure);
-        }
+        taskApiClient.reportFailure(failure);
     }
 
     public List<Finding> createFindings(String zapResult) {

--- a/src/main/java/io/securecodebox/zap/service/zap/ZapService.java
+++ b/src/main/java/io/securecodebox/zap/service/zap/ZapService.java
@@ -164,18 +164,21 @@ public class ZapService implements StatusDetailIndicator {
      * @param target the Target containing a sitemap with all requests to recall
      */
     public void recallTarget(Target target) {
-        if (target.getAttributes().getSitemap() == null) {
+        List<Map<String, Object>> sitemap = target.getAttributes().getSitemap();
+        if (sitemap == null) {
             return;
         }
 
         ObjectMapper objMapper = new ObjectMapper();
 
-        for (Map<String, Object> entry : target.getAttributes().getSitemap()) {
+        log.info("Recalling {} requests to zap.", sitemap.size());
+
+        for (Map<String, Object> entry : sitemap) {
             try {
                 String requestHar = objMapper.writeValueAsString(entry);
                 byte[] response = api.core.sendHarRequest(requestHar, "");
                 String msg = new String(response);
-                log.info("Recalled target to ZAP with following response {}", msg);
+                log.debug("Recalled target to ZAP with following response {}", msg);
             } catch (JsonProcessingException e) {
                 log.error("Couldn't convert Har Request Object to JSON string!", e);
             } catch (ClientApiException e) {

--- a/src/main/java/io/securecodebox/zap/service/zap/ZapService.java
+++ b/src/main/java/io/securecodebox/zap/service/zap/ZapService.java
@@ -214,8 +214,6 @@ public class ZapService implements StatusDetailIndicator {
     public Object startScannerAsUser(String targetUrl, String contextId, String userId) throws ClientApiException {
         log.info("Starting scanner for targetUrl '{}' and userId {}.", targetUrl, userId);
 
-        api.accessUrl(targetUrl);
-
         api.ascan.enableAllScanners(null);
         api.ascan.setOptionHandleAntiCSRFTokens(true);
 

--- a/src/main/java/io/securecodebox/zap/service/zap/ZapService.java
+++ b/src/main/java/io/securecodebox/zap/service/zap/ZapService.java
@@ -350,9 +350,9 @@ public class ZapService implements StatusDetailIndicator {
                 return (JSONObject) entries.get(0);
             }
         } catch (ClientApiException e) {
-            log.warn("Could not fetch Request HAR Object from ZAP.");
+            log.warn("Could not fetch Request HAR Object from ZAP.", e.getMessage());
         } catch (ParseException e) {
-            log.warn("Could not parse Request HAR Object returned from ZAP.");
+            log.warn("Could not parse Request HAR Object returned from ZAP.", e.getMessage());
         }
         return null;
     }

--- a/src/main/java/io/securecodebox/zap/service/zap/ZapService.java
+++ b/src/main/java/io/securecodebox/zap/service/zap/ZapService.java
@@ -316,6 +316,7 @@ public class ZapService implements StatusDetailIndicator {
         log.info("Found #{} alerts for targetUrl: {}", result.size(), targetUrl);
 
         try {
+            log.info("Serializing alerts as json string.");
             return new ObjectMapper().writeValueAsString(findings);
         } catch (JsonProcessingException e) {
             log.error("Couldn't convert List<Alert> to JSON string!", e);

--- a/src/test/java/EngineWorkerJobTest.java
+++ b/src/test/java/EngineWorkerJobTest.java
@@ -22,6 +22,7 @@ import de.otto.edison.jobs.eventbus.JobEventPublisher;
 import io.securecodebox.zap.configuration.ZapConfiguration;
 import io.securecodebox.zap.jobs.definition.EngineWorkerJob;
 import io.securecodebox.zap.service.engine.ZapTaskService;
+import io.securecodebox.zap.service.engine.model.CompleteTask;
 import io.securecodebox.zap.service.engine.model.Finding;
 import io.securecodebox.zap.service.engine.model.Reference;
 import io.securecodebox.zap.service.engine.model.Target;
@@ -69,6 +70,10 @@ public class EngineWorkerJobTest {
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
+        when(
+            taskService.completeTask(any(), any(), any(), any()))
+            .thenReturn(new CompleteTask("1", "1", "zap", new LinkedList<>(), "[]")
+        );
     }
 
     @Test


### PR DESCRIPTION
This PR does two things:

1. Dramatically reduced verbosity of log statements. The target (which can be multiple thousands of lines long) was getting logged multiple times during a scan. This made it nearly impossible to gather useful information from the logs.
2. Removed last use of request proxying. This isn't required anymore and caused some errors when trying to scan some https enabled targets.
3. Zap previously tried to submit full stack traces as incident to the engine. These were often not accepted by the input validations rules. These were replaced by unfortunately more general message, which will not interfere with the validation. For more Information the zap scanner log have to be checked.