### PR TITLE
Removed duplicate target recollection

### DIFF
--- a/src/main/java/io/securecodebox/zap/jobs/definition/EngineWorkerJob.java
+++ b/src/main/java/io/securecodebox/zap/jobs/definition/EngineWorkerJob.java
@@ -170,9 +170,7 @@ public class EngineWorkerJob implements JobRunnable {
             log.info("Starting Scanner Task against target: '{}'", target.getLocation());
 
             String contextId = configureScannerContext(target.getAttributes().getBaseUrl(), target);
-
-            service.recallTarget(target);
-
+            
             String userId = configureAuthentication(target, contextId);
             String result = executeScanner(target, contextId, userId);
 


### PR DESCRIPTION
“recallTarget” was called from both performScannerTask and executeScanner which lead to targets being recalled twice.