### PR TITLE
Removed incorrectly specified config option

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -32,7 +32,6 @@ To configure this service specify the following environment variables:
 | ENGINE_ADDRESS             | http://engine         |                      |
 | ENGINE_BASIC_AUTH_USER     | username              |                      |
 | ENGINE_BASIC_AUTH_PASSWORD | 123456                |                      |
-| SECURECODEBOX_REDUCE_SPIDER_RESULT_ON_REST_SCHEMAS | true/false | Enables a deduplication feature to filter identical URLs |
 
 ### Example for the deduplication feature
 If `SECURECODEBOX_REDUCE_SPIDER_RESULT_ON_REST_SCHEMAS` is `true` the following URLs will be filtered:

--- a/README.MD
+++ b/README.MD
@@ -23,34 +23,24 @@ By default the scanprocess gets started automatically with the startup of the se
 
 >**Note**: This is a SpringBoot Java Application so of course you can also open the project in any Java IDE like IntelliJ and start the scanner from there.
 
-## Configuration Options
+## Container Configuration Options 
 
 To configure this service specify the following environment variables:
 
 | Environment Variable       | Value Example         | Description          |
 | -------------------------- | --------------------- |--------------------- |
-| ENGINE_ADDRESS             | http://engine         |                      |
+| ENGINE_ADDRESS             | http://engine         | Configures the Engine API Endpoint to connect with                     |
 | ENGINE_BASIC_AUTH_USER     | username              |                      |
 | ENGINE_BASIC_AUTH_PASSWORD | 123456                |                      |
 
-### Example for the deduplication feature
-If `SECURECODEBOX_REDUCE_SPIDER_RESULT_ON_REST_SCHEMAS` is `true` the following URLs will be filtered:
-- http://bodgeit:8080/bodgeit/foo/123/bar -> spider result
-  - http://bodgeit:8080/bodgeit/foo/124/bar -> filtered out
-  - http://bodgeit:8080/bodgeit/foo/1555/bar -> filtered out
-- http://bodgeit:8080/bodgeit/foo12/1555/bar -> spider result
-  - http://bodgeit:8080/bodgeit/foo12/1336/bar -> filtered out  
-  - http://bodgeit:8080/bodgeit/foo12/1336/bar -> filtered out  
-- http://bodgeit:8080/bodgeit/foo12/1336/bar/123 -> spider result
-  - http://bodgeit:8080/bodgeit/foo12/1336/bar/12666 -> filtered out
-
+### How to start a ZAP Scan Process
+Please have a look at our [User Guide][scb-user-guide] documentation, which describes in general how to start a scan process, based on the UI or REST API. There is also a [ZAP specific example][scb-user-guide-zap-example].
 
 ## Build with docker
-
 To build the docker container run: `docker build -t CONTAINER_NAME:LABEL .`
 
-
-[scb-project]:              https://github.com/secureCodeBox/secureCodeBox
-[scb-developer-guide]:      https://github.com/secureCodeBox/secureCodeBox/blob/develop/docs/developer-guide/README.md
-[scb-developer-guidelines]: https://github.com/secureCodeBox/secureCodeBox/blob/develop/docs/developer-guide/README.md#guidelines
-[scb-user-guide]:           https://github.com/secureCodeBox/secureCodeBox/tree/develop/docs/user-guide
+[scb-project]:                  https://github.com/secureCodeBox/secureCodeBox
+[scb-developer-guide]:          https://github.com/secureCodeBox/secureCodeBox/blob/master/docs/developer-guide/README.md
+[scb-developer-guidelines]:     https://github.com/secureCodeBox/secureCodeBox/blob/master/docs/developer-guide/README.md#guidelines
+[scb-user-guide]:               https://github.com/secureCodeBox/secureCodeBox/tree/master/docs/user-guide
+[scb-user-guide-zap-example]:   https://github.com/secureCodeBox/secureCodeBox/blob/master/docs/user-guide/usage-examples/zap-bodgeit-example.md

--- a/README.MD
+++ b/README.MD
@@ -33,7 +33,7 @@ To configure this service specify the following environment variables:
 | ENGINE_BASIC_AUTH_USER     | username              |                      |
 | ENGINE_BASIC_AUTH_PASSWORD | 123456                |                      |
 
-### How to start a ZAP Scan Process
+## How to start a ZAP Scan Process
 Please have a look at our [User Guide][scb-user-guide] documentation, which describes in general how to start a scan process, based on the UI or REST API. There is also a [ZAP specific example][scb-user-guide-zap-example].
 
 ## Build with docker


### PR DESCRIPTION
`SECURECODEBOX_REDUCE_SPIDER_RESULT_ON_REST_SCHEMAS` is a target parameter, not a env variable. This should instead by documented in the central user guide.