### PR TITLE
Add basic auth using environment variables

### DIFF
--- a/src/main/java/io/securecodebox/zap/configuration/ZapConfiguration.java
+++ b/src/main/java/io/securecodebox/zap/configuration/ZapConfiguration.java
@@ -48,14 +48,6 @@ public class ZapConfiguration {
     private boolean filterScannerResults;
 
 
-    /**
-     * Note: If the "ENGINE_ADDRESS" environment variable is set, it will override the configuration.
-     */
-    public String getProcessEngineApiUrl() {
-        String env = System.getenv("ENGINE_ADDRESS");
-        return (env != null) ? env : processEngineApiUrl;
-    }
-
     public int getTaskLockDurationInMs() {
         return Integer.parseInt(taskLockDurationInMs);
     }

--- a/src/main/java/io/securecodebox/zap/service/engine/EngineTaskApiClient.java
+++ b/src/main/java/io/securecodebox/zap/service/engine/EngineTaskApiClient.java
@@ -71,7 +71,8 @@ public class EngineTaskApiClient {
         requestFactory.setConnectTimeout(REQUEST_TIMEOUT);
         BufferingClientHttpRequestFactory bufferingRequestFactory = new BufferingClientHttpRequestFactory(requestFactory);
 
-        if (config.getCamundaUsername() != null && config.getCamundaPassword() != null) {
+        if (config.getCamundaUsername() != null && !config.getCamundaUsername().isEmpty()
+                && config.getCamundaPassword() != null && !config.getCamundaPassword().isEmpty()) {
             restTemplate = new BasicAuthRestTemplate(bufferingRequestFactory, config.getCamundaUsername(), config.getCamundaPassword());
         } else {
             restTemplate = new RestTemplate(bufferingRequestFactory);

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -51,9 +51,6 @@ securecodebox.zap.zapPort=8080
 
 securecodebox.zap.processEngineApiUrl=https://localhost/
 
-securecodebox.zap.camundaUsername=kermit
-securecodebox.zap.camundaPassword=a
-
 # How many tasks will be fetched and worked on in parallel?
 securecodebox.zap.maximumTasksToFetchByJob=1
 # How long should a fetched task be locked exclusive for this process (in ms)?

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -49,10 +49,10 @@ securecodebox.zap.spiderType=zap-spider
 securecodebox.zap.zapHost=localhost
 securecodebox.zap.zapPort=8090
 
-securecodebox.zap.processEngineApiUrl=http://engine:8080
-
-securecodebox.zap.camundaUsername=kermit
-securecodebox.zap.camundaPassword=a
+# These properties should be set using environment variables
+securecodebox.zap.processEngineApiUrl=${ENGINE_ADDRESS:http://engine:8080}
+securecodebox.zap.camundaUsername=${ENGINE_BASIC_AUTH_USER:}
+securecodebox.zap.camundaPassword=${ENGINE_BASIC_AUTH_PASSWORD:}
 
 # How many tasks will be fetched and worked on in parallel?
 securecodebox.zap.maximumTasksToFetchByJob=1


### PR DESCRIPTION
- Use scanner-user defined by environment variables to authenticate against engine api instead of default camunda admin user