### PR TITLE
Add alpha and beta active/passiv scan rules

### DIFF
--- a/dockerfiles/init.sh
+++ b/dockerfiles/init.sh
@@ -7,7 +7,7 @@ if [ `id -u` -ge 1000 ]; then
     rm /tmp/passwd
 fi
 
-/zap/zap.sh -Xmx3G -daemon -dir /home/zap/ -port 8090 -host 0.0.0.0 -config api.disablekey=true -config api.addrs.addr.name=.* -config api.addrs.addr.regex=true -addoninstall soap -addoninstall openapi &
+/zap/zap.sh -Xmx3G -daemon -dir /home/zap/ -port 8090 -host 0.0.0.0 -config api.disablekey=true -config api.addrs.addr.name=.* -config api.addrs.addr.regex=true -addoninstall soap -addoninstall openapi -addoninstall ascanrulesBeta -addoninstall ascanrulesAlpha -addoninstall pscanrulesBeta &
 
 sleep 10
 

--- a/dockerfiles/init.sh
+++ b/dockerfiles/init.sh
@@ -7,7 +7,7 @@ if [ `id -u` -ge 1000 ]; then
     rm /tmp/passwd
 fi
 
-/zap/zap.sh -Xmx3G -daemon -dir /home/zap/ -port 8090 -host 0.0.0.0 -config api.disablekey=true -config api.addrs.addr.name=.* -config api.addrs.addr.regex=true -addoninstall soap -addoninstall openapi -addoninstall ascanrulesBeta -addoninstall ascanrulesAlpha -addoninstall pscanrulesBeta &
+/zap/zap.sh -Xmx3G -daemon -dir /home/zap/ -port 8090 -host 0.0.0.0 -config api.disablekey=true -config api.addrs.addr.name=.* -config api.addrs.addr.regex=true -addoninstall soap -addoninstall openapi -addoninstall ascanrulesBeta -addoninstall ascanrulesAlpha -addoninstall pscanrulesBeta -addoninstall pscanrulesAlpha &
 
 sleep 10
 


### PR DESCRIPTION
This is a feature to add alpha/beta scan rules request in form of a pull request (which can be declined).

Alpha/Beta relates to how useful from ZAPs point of view they are for general public.

Please be aware that this might enhances the False Positive rate.

(Active) Scan Rules Beta (the other rules are located in the navigation on the right): https://github.com/zaproxy/zap-extensions/wiki/HelpAddonsAscanrulesBetaAscanbeta

The source for the active scan rule beta is located at https://github.com/zaproxy/zap-extensions/tree/beta/src/org/zaproxy/zap/extension/ascanrulesBeta