### PR TITLE
Bugfix/zap replacer plugin

### DIFF
--- a/src/main/java/io/securecodebox/zap/jobs/definition/EngineWorkerJob.java
+++ b/src/main/java/io/securecodebox/zap/jobs/definition/EngineWorkerJob.java
@@ -223,7 +223,7 @@ public class EngineWorkerJob implements JobRunnable {
         ZapReplacerRule[] zapReplacerRules = target.getAttributes().getZapReplacerRules();
 
         log.debug("Start Spider with URL: " + target.getLocation());
-        String scanId = (String) service.startSpiderAsUser(target.getLocation(), spiderApiSpecUrl,
+        String scanId = service.startSpiderAsUser(target.getLocation(), spiderApiSpecUrl,
                 spiderMaxDepth, contextId, userId, zapReplacerRules);
         return service.retrieveSpiderResult(scanId);
     }
@@ -236,7 +236,7 @@ public class EngineWorkerJob implements JobRunnable {
         ZapReplacerRule[] zapReplacerRules = target.getAttributes().getZapReplacerRules();
 
         log.debug("Start Scanner with URL: " + target.getLocation());
-        String scanId = (String) service.startScannerAsUser(target.getLocation(), contextId, userId, delayInMs, threadsPerHost, zapReplacerRules);
+        String scanId = service.startScannerAsUser(target.getLocation(), contextId, userId, delayInMs, threadsPerHost, zapReplacerRules);
         return service.retrieveScannerResult(scanId, target.getLocation());
     }
 

--- a/src/main/java/io/securecodebox/zap/service/engine/EngineTaskApiClient.java
+++ b/src/main/java/io/securecodebox/zap/service/engine/EngineTaskApiClient.java
@@ -87,25 +87,13 @@ public class EngineTaskApiClient {
      * @return Returns true if the configured SCB Engine API is available and at least one processModell is deployed.
      */
     boolean isApiAvailable() {
-        return (this.countProcesses() > 0);
-    }
-
-    /**
-     * @return Returns the number of currently deployed process models which are available at the SCB Engine.
-     */
-    int countProcesses() {
-
-        String url = config.getProcessEngineApiUrl() + "/box/processes/";
-        log.debug("Call countProcesses() via {}", url);
+        String url = config.getProcessEngineApiUrl() + "/status";
+        log.debug("Call engine status via {}", url);
 
         ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
-        log.debug(String.format("Result for countProcesses(): %s", response));
+        log.debug(String.format("Engine api status: %s", response));
 
-        if (response.getStatusCode().is2xxSuccessful() && response.getHeaders().getContentType().isCompatibleWith(MediaType.APPLICATION_JSON) && !response.toString().isEmpty()) {
-            return response.toString().split("id").length;
-        } else {
-            return 0;
-        }
+        return response.getStatusCode().is2xxSuccessful();
     }
 
     ZapTask fetchAndLockTask(ZapTopic zapTopic, String jobId) {

--- a/src/main/java/io/securecodebox/zap/service/engine/ZapTaskService.java
+++ b/src/main/java/io/securecodebox/zap/service/engine/ZapTaskService.java
@@ -88,11 +88,9 @@ public class ZapTaskService extends TaskService {
     @Override
     public StatusDetail statusDetail() {
         try {
-            boolean isApiAvailable = this.isApiAvailable();
-
-            if (isApiAvailable) {
+            if (this.isApiAvailable()) {
                 log.debug("Internal health check: OK");
-                return StatusDetail.statusDetail("Engine SCB API", Status.OK, "The Engine API is up and running", singletonMap("Deployed Processes", String.valueOf(this.taskApiClient.countProcesses())));
+                return StatusDetail.statusDetail("Engine SCB API", Status.OK, "The Engine API is up and running");
             } else {
                 return StatusDetail.statusDetail("Engine SCB API", Status.WARNING, "Couldn't reach the Engine API!");
             }

--- a/src/main/java/io/securecodebox/zap/service/zap/ReplacerPluginConfigurator.java
+++ b/src/main/java/io/securecodebox/zap/service/zap/ReplacerPluginConfigurator.java
@@ -1,0 +1,129 @@
+package io.securecodebox.zap.service.zap;
+
+import io.securecodebox.zap.service.engine.model.zap.ZapReplacerRule;
+import javax.validation.constraints.NotNull;
+import lombok.extern.slf4j.Slf4j;
+import org.zaproxy.clientapi.core.ApiResponseList;
+import org.zaproxy.clientapi.core.ApiResponseSet;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
+
+@Slf4j
+public class ReplacerPluginConfigurator {
+
+    private ClientApi api;
+
+    public ReplacerPluginConfigurator(ClientApi api) {
+        this.api = api;
+    }
+
+    public void configureZapWithReplacerRules(ZapReplacerRule[] replacerRules) throws ClientApiException {
+        resetReplacerRules();
+        if (replacerRules != null && replacerRules.length > 0) {
+            log.debug("Adding {} custom ZAP replacer rules", replacerRules.length);
+            addReplacerRules(replacerRules);
+        } else {
+            log.info("No custom ZAP replacer rule defined.");
+        }
+    }
+
+    /**
+     * Gets and converts the API wrapper request "replacer.rules()"
+     *
+     * @return array of replacer rules
+     * @throws ClientApiException can be thrown for any api request
+     */
+    final ZapReplacerRule[] getCurrentReplacerRules() throws ClientApiException {
+        return ((ApiResponseList) api.replacer.rules()).getItems().stream()
+                .map(i -> ((ApiResponseSet) i))
+                .map(i -> {
+                    ZapReplacerRule rule = new ZapReplacerRule();
+                    rule.setMatchType(i.getStringValue("matchType"));
+                    rule.setDescription(i.getStringValue("description"));
+                    rule.setMatchString(i.getStringValue("matchString"));
+                    rule.setInitiators(i.getStringValue("initiators"));
+                    rule.setMatchRegex(i.getStringValue("matchRegex"));
+                    rule.setReplacement(i.getStringValue("replacement"));
+                    rule.setEnabled(i.getStringValue("enabled"));
+                    return rule;
+                })
+                .toArray(ZapReplacerRule[]::new);
+    }
+
+    /**
+     * Adds ZAP replacer rules
+     *
+     * @param rules
+     * @throws ClientApiException thrown if at least one rule cannot be set
+     */
+    void addReplacerRules(ZapReplacerRule[] rules) throws ClientApiException {
+        if (rules != null && rules.length > 0) {
+            log.debug("Adding #{} exiting replacer rules", rules.length);
+            for (ZapReplacerRule rule: rules) {
+                if (rule != null) {
+                    addReplacerRule(rule);
+                } else {
+                    log.warn("Couldn't add the replacer rule, the rule must not be null ot empty.");
+                }
+            }
+        } else {
+            log.warn("There is no replacer rule to add.");
+        }
+    }
+
+    void resetReplacerRules() throws ClientApiException {
+        log.debug("Resetting ZAP replacer rules");
+        ZapReplacerRule[] currentRules = getCurrentReplacerRules();
+        if (currentRules != null && currentRules.length > 0) {
+            removeReplacerRules(currentRules);
+        }
+    }
+
+    /**
+     * Adds ZAP replacer rule
+     *
+     * @param rule
+     * @throws ClientApiException thrown if rule cannot be set
+     */
+    private void addReplacerRule(@NotNull ZapReplacerRule rule) throws ClientApiException {
+        api.replacer.addRule(
+                rule.getDescription(),
+                rule.getEnabled(),
+                rule.getMatchType(),
+                rule.getMatchRegex(),
+                rule.getMatchString(),
+                rule.getReplacement(),
+                rule.getInitiators());
+    }
+
+    /**
+     * Removes the given list of ZAP replacer rules.
+     *
+     * @param rules The list of ZAP replacer rules to remove.
+     * @throws ClientApiException thrown if at least one of the rules cannot be removed
+     */
+    private void removeReplacerRules(@NotNull ZapReplacerRule[] rules) throws ClientApiException {
+        if (rules != null && rules.length > 0) {
+            log.debug("Removing #{} exiting replacer rules", rules.length);
+            for (ZapReplacerRule rule : rules){
+                removeReplacerRule(rule);
+            }
+        } else {
+            log.warn("There are no replacer rules to remove.");
+        }
+    }
+
+    /**
+     * Removes a single ZAP replacer rule.
+     *
+     * @param rule The ZAP replacer rule to remove.
+     * @throws ClientApiException thrown if rule cannot be removed
+     */
+    private void removeReplacerRule(@NotNull ZapReplacerRule rule) throws ClientApiException {
+        if (rule != null) {
+            api.replacer.removeRule(rule.getDescription());
+        } else {
+            log.warn("You can't remove a replacer rule which is null.");
+        }
+    }
+}

--- a/src/main/java/io/securecodebox/zap/service/zap/ZapService.java
+++ b/src/main/java/io/securecodebox/zap/service/zap/ZapService.java
@@ -35,19 +35,27 @@ import io.securecodebox.zap.service.engine.model.Reference;
 import io.securecodebox.zap.service.engine.model.Target;
 import io.securecodebox.zap.service.engine.model.zap.ZapReplacerRule;
 import io.securecodebox.zap.service.engine.model.zap.ZapSitemapEntry;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.PostConstruct;
+import javax.validation.constraints.NotNull;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.zaproxy.clientapi.core.*;
+import org.zaproxy.clientapi.core.Alert;
+import org.zaproxy.clientapi.core.ApiResponse;
+import org.zaproxy.clientapi.core.ApiResponseElement;
+import org.zaproxy.clientapi.core.ApiResponseList;
+import org.zaproxy.clientapi.core.ApiResponseSet;
+import org.zaproxy.clientapi.core.ClientApi;
+import org.zaproxy.clientapi.core.ClientApiException;
 import org.zaproxy.clientapi.gen.Context;
 
-import javax.annotation.PostConstruct;
-import javax.validation.constraints.NotNull;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.util.*;
-import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonMap;
 
@@ -65,22 +73,27 @@ public class ZapService implements StatusDetailIndicator {
     private static final String AUTH_USER = "Testuser";
     private static final String AUTH_FORM_BASED = "formBasedAuthentication";
     private static final String AUTH_SCRIPT_BASED = "scriptBasedAuthentication";
-
-    private final ZapConfiguration config;
-    private ClientApi api;
-
     private static Integer defaultDelayInMs;
     private static Integer defaultThreadsPerHost;
+    private final ZapConfiguration config;
+    private ClientApi api;
 
     @Autowired
     public ZapService(ZapConfiguration config) {
         this.config = config;
     }
 
+    private static String getSingleResult(ApiResponse response) {
+        if (response instanceof ApiResponseElement) {
+            return ((ApiResponseElement) response).getValue();
+        }
+        return "";
+    }
+
     @PostConstruct
     public void init() throws ClientApiException {
         api = new ClientApi(config.getZapHost(), config.getZapPort());
-        if( defaultDelayInMs == null && defaultThreadsPerHost == null) {
+        if (defaultDelayInMs == null && defaultThreadsPerHost == null) {
             defaultDelayInMs = Integer.valueOf(api.ascan.optionDelayInMs().toString());
             defaultThreadsPerHost = Integer.valueOf(api.ascan.optionThreadPerHost().toString());
             log.debug("Set default rate limits to defaultDelayInMs:{}, defaultThreadsPerHost:{}", defaultDelayInMs, defaultThreadsPerHost);
@@ -201,15 +214,14 @@ public class ZapService implements StatusDetailIndicator {
      * @param userId User ID to start the spider scan as, "-1" to ignore
      * @return New spider scan ID
      */
-    public Object startSpiderAsUser(String targetUrl, String apiSpecUrl, int maxDepth, String contextId, String userId, ZapReplacerRule[] replacerRules) throws ClientApiException {
+    public String startSpiderAsUser(String targetUrl, String apiSpecUrl, int maxDepth, String contextId, String userId, ZapReplacerRule[] replacerRules) throws ClientApiException {
         log.info("Starting spider for targetUrl '{}' and with apiSpecUrl '{}' and maxDepth '{}'", targetUrl, apiSpecUrl, maxDepth);
 
         resetReplacerRules();
         if (replacerRules != null && replacerRules.length > 0) {
             log.info("Adding {} custom ZAP replacer rules", replacerRules.length);
             addReplacerRules(replacerRules);
-        }
-        else {
+        } else {
             log.info("No custom ZAP replacer rule defined yet.");
         }
 
@@ -230,18 +242,16 @@ public class ZapService implements StatusDetailIndicator {
         return getSingleResult(response);
     }
 
-
     /**
-     * @param userId User ID to start the scan as, "-1" to ignore
-     * @param delayInMs delay between reuests (optional)
+     * @param userId         User ID to start the scan as, "-1" to ignore
+     * @param delayInMs      delay between reuests (optional)
      * @param threadsPerHost maximum number of concurrent connections to host (optional)
-     * @param replacerRules replacer plugin rules, see
-     *                         https://github.com/zaproxy/zap-extensions/wiki/HelpAddonsReplacerReplacer
+     * @param replacerRules  replacer plugin rules, see
+     *                       https://github.com/zaproxy/zap-extensions/wiki/HelpAddonsReplacerReplacer
      * @return New scanner scan ID
      */
-    public Object startScannerAsUser(String targetUrl, String contextId, String userId, Integer delayInMs, Integer threadsPerHost, ZapReplacerRule[] replacerRules) throws ClientApiException {
+    public String startScannerAsUser(String targetUrl, String contextId, String userId, Integer delayInMs, Integer threadsPerHost, ZapReplacerRule[] replacerRules) throws ClientApiException {
         log.info("Starting scanner for targetUrl '{}' and userId {}.", targetUrl, userId);
-
 
         api.ascan.enableAllScanners(null);
         api.ascan.setOptionHandleAntiCSRFTokens(true);
@@ -251,8 +261,7 @@ public class ZapService implements StatusDetailIndicator {
         if (replacerRules != null && replacerRules.length > 0) {
             log.debug("Adding {} custom ZAP replacer rules", replacerRules.length);
             addReplacerRules(replacerRules);
-        }
-        else {
+        } else {
             log.info("No custom ZAP replacer rule defined yet.");
         }
 
@@ -282,14 +291,13 @@ public class ZapService implements StatusDetailIndicator {
         }
     }
 
-
-
     /**
      * Gets and converts the API wrapper request "replacer.rules()"
+     *
      * @return array of replacer rules
      * @throws ClientApiException can be thrown for any api request
      */
-    private final ZapReplacerRule[] getCurrentReplacerRules () throws ClientApiException {
+    private final ZapReplacerRule[] getCurrentReplacerRules() throws ClientApiException {
         return ((ApiResponseList) api.replacer.rules()).getItems().stream()
                 .map(i -> ((ApiResponseSet) i))
                 .map(i -> {
@@ -306,36 +314,34 @@ public class ZapService implements StatusDetailIndicator {
                 .toArray(ZapReplacerRule[]::new);
     }
 
-
     /**
      * Adds ZAP replacer rules
+     *
      * @param rules
      * @throws ClientApiException thrown if at least one rule cannot be set
      */
-    private void addReplacerRules (ZapReplacerRule[] rules) throws ClientApiException {
-        if(rules != null && rules.length > 0) {
+    private void addReplacerRules(ZapReplacerRule[] rules) throws ClientApiException {
+        if (rules != null && rules.length > 0) {
             log.debug("Adding #{} exiting replacer rules", rules.length);
-            for (int i = 0; i < rules.length; i++)
-                if(rules[i] != null){
+            for (int i = 0; i < rules.length; i++) {
+                if (rules[i] != null) {
                     addReplacerRule(rules[i]);
-                }
-                else
-                {
+                } else {
                     log.warn("Couldn't add the replacer rule, the rule must not be null ot empty.");
                 }
-        }
-        else
-        {
+            }
+        } else {
             log.warn("There is no replacer rule to add.");
         }
     }
 
     /**
      * Adds ZAP replacer rule
+     *
      * @param rule
      * @throws ClientApiException thrown if rule cannot be set
      */
-    private void addReplacerRule (@NotNull ZapReplacerRule rule) throws ClientApiException {
+    private void addReplacerRule(@NotNull ZapReplacerRule rule) throws ClientApiException {
         api.replacer.addRule(
                 rule.getDescription(),
                 rule.getEnabled(),
@@ -346,51 +352,47 @@ public class ZapService implements StatusDetailIndicator {
                 rule.getInitiators());
     }
 
-
     /**
      * Removes all currently defined replacer rules.
+     *
      * @throws ClientApiException
      */
     private void resetReplacerRules() throws ClientApiException {
         ZapReplacerRule[] currentRules = getCurrentReplacerRules();
         log.debug("Resetting ZAP replacer rules, currently there are #{} of them configured.", getCurrentReplacerRules().length);
 
-        if(currentRules != null && currentRules.length > 0) {
+        if (currentRules != null && currentRules.length > 0) {
             removeReplacerRules(currentRules);
-        }
-        else
-        {
+        } else {
             log.debug("Ignore resetting the replacer rules, because there is no rule.");
         }
     }
 
     /**
      * Removes the given list of ZAP replacer rules.
+     *
      * @param rules The list of ZAP replacer rules to remove.
      * @throws ClientApiException thrown if at least one of the rules cannot be removed
      */
-    private void removeReplacerRules (@NotNull ZapReplacerRule[] rules) throws ClientApiException {
-        if(rules != null && rules.length > 0) {
+    private void removeReplacerRules(@NotNull ZapReplacerRule[] rules) throws ClientApiException {
+        if (rules != null && rules.length > 0) {
             log.debug("Removing #{} exiting replacer rules", rules.length);
             for (int i = 0; i < rules.length; i++) removeReplacerRule(rules[i]);
-        }
-        else
-        {
+        } else {
             log.warn("There is no replacer rule to remove.");
         }
     }
 
     /**
      * Removes a single ZAP replacer rule.
+     *
      * @param rule The ZAP replacer rule to remove.
      * @throws ClientApiException thrown if rule cannot be removed
      */
-    private void removeReplacerRule (@NotNull ZapReplacerRule rule) throws ClientApiException {
-        if(rule != null) {
+    private void removeReplacerRule(@NotNull ZapReplacerRule rule) throws ClientApiException {
+        if (rule != null) {
             api.replacer.removeRule(rule.getDescription());
-        }
-        else
-        {
+        } else {
             log.warn("You can't remove a replacer rule which is null.");
         }
     }
@@ -422,7 +424,7 @@ public class ZapService implements StatusDetailIndicator {
                     .filter(r -> r instanceof ApiResponseSet)
                     .map(r -> {
                         Finding finding = new Finding();
-                        HarRequest harRequest = getHarRequestPortionForRequest(((ApiResponseSet)r).getStringValue("messageId"));
+                        HarRequest harRequest = getHarRequestPortionForRequest(((ApiResponseSet) r).getStringValue("messageId"));
                         finding.setLocation(harRequest.getUrl());
                         finding.getAttributes().put("request", harRequest);
                         return finding;
@@ -474,8 +476,8 @@ public class ZapService implements StatusDetailIndicator {
             finding.getAttributes().put("OTHER_REFERENCES", alert.getReference().split("\n"));
 
             Reference reference = new Reference();
-            reference.setId("CVE-"+ alert.getCweId());
-            reference.setSource("https://cwe.mitre.org/data/definitions/" + alert.getCweId() +".html");
+            reference.setId("CVE-" + alert.getCweId());
+            reference.setSource("https://cwe.mitre.org/data/definitions/" + alert.getCweId() + ".html");
             finding.setReference(reference);
 
             return finding;
@@ -485,17 +487,10 @@ public class ZapService implements StatusDetailIndicator {
         return findings;
     }
 
-    private static String getSingleResult(ApiResponse response) {
-        if (response instanceof ApiResponseElement) {
-            return ((ApiResponseElement) response).getValue();
-        }
-        return "";
-    }
-
     /**
      * Returns the HAR (HTTP Archive) of a single entry in the ZAP Tree.
      * Currently only the request portion is required and used.
-     *
+     * <p>
      * This sends a Request to the ZapAPI
      *
      * @param requestId aka MessageId
@@ -515,10 +510,10 @@ public class ZapService implements StatusDetailIndicator {
         return null;
     }
 
-    HarRequest getHarRequestPortionForRequest(String requestId){
+    HarRequest getHarRequestPortionForRequest(String requestId) {
         Har har = getHarForRequest(requestId);
 
-        if(har.getLog().getEntries().size() == 0){
+        if (har.getLog().getEntries().size() == 0) {
             return null;
         }
 

--- a/src/main/java/io/securecodebox/zap/service/zap/ZapService.java
+++ b/src/main/java/io/securecodebox/zap/service/zap/ZapService.java
@@ -73,10 +73,13 @@ public class ZapService implements StatusDetailIndicator {
     private static final String AUTH_USER = "Testuser";
     private static final String AUTH_FORM_BASED = "formBasedAuthentication";
     private static final String AUTH_SCRIPT_BASED = "scriptBasedAuthentication";
+
     private static Integer defaultDelayInMs;
     private static Integer defaultThreadsPerHost;
+
     private final ZapConfiguration config;
     private ClientApi api;
+    private ReplacerPluginConfigurator replacerPluginConfigurator;
 
     @Autowired
     public ZapService(ZapConfiguration config) {
@@ -93,6 +96,8 @@ public class ZapService implements StatusDetailIndicator {
     @PostConstruct
     public void init() throws ClientApiException {
         api = new ClientApi(config.getZapHost(), config.getZapPort());
+        replacerPluginConfigurator = new ReplacerPluginConfigurator(api);
+
         if (defaultDelayInMs == null && defaultThreadsPerHost == null) {
             defaultDelayInMs = Integer.valueOf(api.ascan.optionDelayInMs().toString());
             defaultThreadsPerHost = Integer.valueOf(api.ascan.optionThreadPerHost().toString());
@@ -133,6 +138,10 @@ public class ZapService implements StatusDetailIndicator {
     }
 
     public void clearSession() throws ClientApiException {
+        api.spider.removeAllScans();
+        api.ascan.removeAllScans();
+        replacerPluginConfigurator.resetReplacerRules();
+
         api.core.newSession(SESSION_NAME, "true");
     }
 
@@ -185,17 +194,17 @@ public class ZapService implements StatusDetailIndicator {
      *
      * @param target the Target containing a sitemap with all requests to recall
      */
-    public void recallTarget(Target target) {
+    public void recallTarget(Target target, ZapReplacerRule[] zapReplacerRules) throws ClientApiException {
         List<ZapSitemapEntry> sitemap = target.getAttributes().getSitemap();
         if (sitemap == null) {
             log.warn("Tried to recall a empty sitemap to Zap. The scan will fail as it will not have any targets to scan!");
             return;
         }
 
-        ObjectMapper objMapper = new ObjectMapper();
+        replacerPluginConfigurator.configureZapWithReplacerRules(zapReplacerRules);
 
         log.info("Recalling {} requests to zap.", sitemap.size());
-
+        ObjectMapper objMapper = new ObjectMapper();
         for (ZapSitemapEntry entry : sitemap) {
             try {
                 String requestHar = objMapper.writeValueAsString(entry);
@@ -217,13 +226,7 @@ public class ZapService implements StatusDetailIndicator {
     public String startSpiderAsUser(String targetUrl, String apiSpecUrl, int maxDepth, String contextId, String userId, ZapReplacerRule[] replacerRules) throws ClientApiException {
         log.info("Starting spider for targetUrl '{}' and with apiSpecUrl '{}' and maxDepth '{}'", targetUrl, apiSpecUrl, maxDepth);
 
-        resetReplacerRules();
-        if (replacerRules != null && replacerRules.length > 0) {
-            log.info("Adding {} custom ZAP replacer rules", replacerRules.length);
-            addReplacerRules(replacerRules);
-        } else {
-            log.info("No custom ZAP replacer rule defined yet.");
-        }
+        replacerPluginConfigurator.configureZapWithReplacerRules(replacerRules);
 
         if (apiSpecUrl != null && !apiSpecUrl.isEmpty()) {
             api.openapi.importUrl(apiSpecUrl, null);
@@ -257,13 +260,7 @@ public class ZapService implements StatusDetailIndicator {
         api.ascan.setOptionHandleAntiCSRFTokens(true);
         setRateLimits(delayInMs, threadsPerHost);
 
-        resetReplacerRules();
-        if (replacerRules != null && replacerRules.length > 0) {
-            log.debug("Adding {} custom ZAP replacer rules", replacerRules.length);
-            addReplacerRules(replacerRules);
-        } else {
-            log.info("No custom ZAP replacer rule defined yet.");
-        }
+        replacerPluginConfigurator.configureZapWithReplacerRules(replacerRules);
 
         ApiResponse response = ("-1".equals(userId))
                 ? api.ascan.scan(targetUrl, "true", "false", null, null, null)
@@ -288,112 +285,6 @@ public class ZapService implements StatusDetailIndicator {
         } else {
             log.debug("Set threadsPerHost to default ({})", defaultThreadsPerHost);
             api.ascan.setOptionThreadPerHost(defaultThreadsPerHost);
-        }
-    }
-
-    /**
-     * Gets and converts the API wrapper request "replacer.rules()"
-     *
-     * @return array of replacer rules
-     * @throws ClientApiException can be thrown for any api request
-     */
-    private final ZapReplacerRule[] getCurrentReplacerRules() throws ClientApiException {
-        return ((ApiResponseList) api.replacer.rules()).getItems().stream()
-                .map(i -> ((ApiResponseSet) i))
-                .map(i -> {
-                    ZapReplacerRule rule = new ZapReplacerRule();
-                    rule.setMatchType(i.getStringValue("matchType"));
-                    rule.setDescription(i.getStringValue("description"));
-                    rule.setMatchString(i.getStringValue("matchString"));
-                    rule.setInitiators(i.getStringValue("initiators"));
-                    rule.setMatchRegex(i.getStringValue("matchRegex"));
-                    rule.setReplacement(i.getStringValue("replacement"));
-                    rule.setEnabled(i.getStringValue("enabled"));
-                    return rule;
-                })
-                .toArray(ZapReplacerRule[]::new);
-    }
-
-    /**
-     * Adds ZAP replacer rules
-     *
-     * @param rules
-     * @throws ClientApiException thrown if at least one rule cannot be set
-     */
-    private void addReplacerRules(ZapReplacerRule[] rules) throws ClientApiException {
-        if (rules != null && rules.length > 0) {
-            log.debug("Adding #{} exiting replacer rules", rules.length);
-            for (int i = 0; i < rules.length; i++) {
-                if (rules[i] != null) {
-                    addReplacerRule(rules[i]);
-                } else {
-                    log.warn("Couldn't add the replacer rule, the rule must not be null ot empty.");
-                }
-            }
-        } else {
-            log.warn("There is no replacer rule to add.");
-        }
-    }
-
-    /**
-     * Adds ZAP replacer rule
-     *
-     * @param rule
-     * @throws ClientApiException thrown if rule cannot be set
-     */
-    private void addReplacerRule(@NotNull ZapReplacerRule rule) throws ClientApiException {
-        api.replacer.addRule(
-                rule.getDescription(),
-                rule.getEnabled(),
-                rule.getMatchType(),
-                rule.getMatchRegex(),
-                rule.getMatchString(),
-                rule.getReplacement(),
-                rule.getInitiators());
-    }
-
-    /**
-     * Removes all currently defined replacer rules.
-     *
-     * @throws ClientApiException
-     */
-    private void resetReplacerRules() throws ClientApiException {
-        ZapReplacerRule[] currentRules = getCurrentReplacerRules();
-        log.debug("Resetting ZAP replacer rules, currently there are #{} of them configured.", getCurrentReplacerRules().length);
-
-        if (currentRules != null && currentRules.length > 0) {
-            removeReplacerRules(currentRules);
-        } else {
-            log.debug("Ignore resetting the replacer rules, because there is no rule.");
-        }
-    }
-
-    /**
-     * Removes the given list of ZAP replacer rules.
-     *
-     * @param rules The list of ZAP replacer rules to remove.
-     * @throws ClientApiException thrown if at least one of the rules cannot be removed
-     */
-    private void removeReplacerRules(@NotNull ZapReplacerRule[] rules) throws ClientApiException {
-        if (rules != null && rules.length > 0) {
-            log.debug("Removing #{} exiting replacer rules", rules.length);
-            for (int i = 0; i < rules.length; i++) removeReplacerRule(rules[i]);
-        } else {
-            log.warn("There is no replacer rule to remove.");
-        }
-    }
-
-    /**
-     * Removes a single ZAP replacer rule.
-     *
-     * @param rule The ZAP replacer rule to remove.
-     * @throws ClientApiException thrown if rule cannot be removed
-     */
-    private void removeReplacerRule(@NotNull ZapReplacerRule rule) throws ClientApiException {
-        if (rule != null) {
-            api.replacer.removeRule(rule.getDescription());
-        } else {
-            log.warn("You can't remove a replacer rule which is null.");
         }
     }
 
@@ -521,7 +412,7 @@ public class ZapService implements StatusDetailIndicator {
     }
 
     /**
-     * This status checks if the configured ZAP API is reachable and returning a API result.
+     * This status checks if the configured ZAP API is reachable and returning an API result.
      *
      * @return
      */


### PR DESCRIPTION

- configured replacerPlugin with replacer rules before recalling targets from sitemap
- moved replacer plugin methods to own class "ReplacerPluginConfigurator"
- some code formatting and cleanup
- fixed api status check. (Scanners are not authorized to use definitions endpoint so use engine status endpoint instead)