### PR TITLE
Update to ZAP 2.9.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV SCB_REPOSITORY_URL ${REPOSITORY_URL}
 
 RUN gradle clean build -Pvcs_commit=${SCB_COMMIT_ID} -Pvcs_version=${SCB_BRANCH} -Pvcs_url=${SCB_REPOSITORY_URL}
 
-FROM owasp/zap2docker-stable:2.8.0
+FROM owasp/zap2docker-bare:2.9.0
 
 COPY dockerfiles/init.sh /home/zap/init.sh
 COPY dockerfiles/csrfAuthScript.js /home/zap/scripts/templates/authentication/csrfAuthScript.js


### PR DESCRIPTION
- Update to ZAP 2.9.0
- Use `bare` image instead of full image to reduce size